### PR TITLE
Add an abstraction layer for cache handlers.

### DIFF
--- a/data/cache/handler/__init__.py
+++ b/data/cache/handler/__init__.py
@@ -19,5 +19,6 @@
 #===============================================================================
 
 
+from .cacheHandler import CacheHandler
 from .jsonCacheHandler import JsonCacheHandler
 from .exception import TypeFetchError

--- a/data/cache/handler/cacheHandler.py
+++ b/data/cache/handler/cacheHandler.py
@@ -1,0 +1,32 @@
+from abc import ABCMeta
+from abc import abstractmethod
+
+
+class CacheHandler(metaclass=ABCMeta):
+  """Abstract base class for cache handlers."""
+
+
+  @abstractmethod
+  def getType(self, typeID):
+    ...
+
+  @abstractmethod
+  def getAttribute(self, attrID):
+    ...
+
+  @abstractmethod
+  def getEffect(self, effectID):
+    ...
+
+  @abstractmethod
+  def getModifier(self, modifierID):
+    ...
+
+  @abstractmethod
+  def getFingerprint(self):
+    ...
+
+  @abstractmethod
+  def updateCache(self, data, fingerprint):
+    ...
+

--- a/data/cache/handler/jsonCacheHandler.py
+++ b/data/cache/handler/jsonCacheHandler.py
@@ -24,11 +24,12 @@ import json
 import os.path
 from weakref import WeakValueDictionary
 
+from eos.data.cache.handler import CacheHandler
 from eos.data.cache.object import *
 from .exception import TypeFetchError, AttributeFetchError, EffectFetchError, ModifierFetchError
 
 
-class JsonCacheHandler:
+class JsonCacheHandler(CacheHandler):
     """
     Each time Eos is initialized, it loads data from packed JSON
     (disk cache) into memory data cache, and uses it to instantiate

--- a/data/dataHandler/__init__.py
+++ b/data/dataHandler/__init__.py
@@ -19,4 +19,5 @@
 #===============================================================================
 
 
+from .dataHandler import DataHandler
 from .jsonDataHandler import JsonDataHandler


### PR DESCRIPTION
This way, anyone can write their own cache handler and pass it to Eos. Also
exposed the data handler and new cache handler abstract classes so you can
easily import them.

Changed the name of initializeData to initializeCache as it made more sense,
since you're creating a cache from your data.
