### PR TITLE
Handle item with no requirements

### DIFF
--- a/eos/fit/restriction_tracker/register/capital_item.py
+++ b/eos/fit/restriction_tracker/register/capital_item.py
@@ -78,7 +78,11 @@ class CapitalItemRegister(RestrictionRegister):
         except AttributeError:
             pass
         else:
-            if Type.capital_ships in ship_item.required_skills:
+            if ship_item.required_skills:
+                if (Type.capital_ships in ship_item.required_skills):
+                    return
+            else:
+                # There are no skills attached to the item, so return without error
                 return
         # If we got here, then we're dealing with non-capital
         # ship, and all registered holders are tainted


### PR DESCRIPTION
Capital items assumed an item with no requirements failed the check, when in reality there is no way to validate the requirements.  If an item has no requirements listed (like structure modules), just quietly continue rather than throwing exceptions.