### PR TITLE
Add gitignore for .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/
 # Pycharm project files
 .idea
 eos.iml
+
+# pyCharm cache for running tests
+.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 # Compiled python files
 *.pyc
 *.pyo
-__pycache__
-*.egg-info/
-dist/
-build/
 
 # Eclipse project files
 .project
@@ -14,5 +10,96 @@ build/
 .idea
 eos.iml
 
-# pyCharm cache for running tests
-.cache/
+# Exceptions below from:
+# https://github.com/github/gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject


### PR DESCRIPTION
This is a folder created when you use pyCharm to run tests, it stores useful info such as the last test that failed.

Useful, but we don't want it on Github. :)